### PR TITLE
Update the logic of the provider's state

### DIFF
--- a/fed_mgr/v1/identity_providers/user_groups/slas/projects/crud.py
+++ b/fed_mgr/v1/identity_providers/user_groups/slas/projects/crud.py
@@ -19,8 +19,8 @@ def connect_proj_to_sla(
 
     If the project already has an SLA associated, overwrite the existing one.
 
-    If the project is the root one and the provider is in the `draft` state, update the
-    provider state to `ready`.
+    If the project is the root one and the provider is in the `submitted` state, update
+    the provider state to `ready`.
 
     Args:
         session (SessionDep): The database session used for committing changes.
@@ -32,7 +32,7 @@ def connect_proj_to_sla(
         None
 
     """
-    if project.is_root and project.provider.status == ProviderStatus.draft:
+    if project.is_root and project.provider.status == ProviderStatus.submitted:
         project.provider.status = ProviderStatus.ready
     project.sla = sla
     project.updated_by = updated_by
@@ -49,7 +49,7 @@ def disconnect_proj_from_sla(
     raise a ConflictError.
 
     If the project it the root one and the hosting provider is in the `ready` state,
-    update the provider state to `draft`.
+    update the provider state to `submitted`.
 
     If the project it the root one and the hosting provider is in the `ready` state, or
     the project is not the root one (independently of the provider's state) sets the
@@ -71,7 +71,7 @@ def disconnect_proj_from_sla(
             f"not in the {ProviderStatus.ready.name} state"
         )
     if project.is_root:
-        project.provider.status = ProviderStatus.draft
+        project.provider.status = ProviderStatus.submitted
     project.sla = None
     project.updated_by = updated_by
     session.add(project)

--- a/fed_mgr/v1/providers/schemas.py
+++ b/fed_mgr/v1/providers/schemas.py
@@ -37,8 +37,8 @@ class ProviderStatus(int, Enum):
     """Enumeration of possible resource provider statuses."""
 
     draft = 0
-    ready = 1
-    submitted = 2
+    submitted = 1
+    ready = 2
     evaluation = 3
     pre_production = 4
     active = 5

--- a/tests/v1/cruds/test_projects_crud.py
+++ b/tests/v1/cruds/test_projects_crud.py
@@ -139,7 +139,7 @@ def test_connect_proj_to_sla(session):
     project = MagicMock(spec=Project)
     project.is_root = False
     project.provider = MagicMock(spec=Provider)
-    project.provider.status = ProviderStatus.draft
+    project.provider.status = ProviderStatus.submitted
     sla = MagicMock(spec=Project)
     updated_by = MagicMock(spec=User)
     connect_proj_to_sla(
@@ -147,7 +147,7 @@ def test_connect_proj_to_sla(session):
     )
     session.add.assert_called_once_with(project)
     session.commit.assert_called_once()
-    assert project.provider.status == ProviderStatus.draft
+    assert project.provider.status == ProviderStatus.submitted
     assert project.sla == sla
     assert project.updated_by == updated_by
 
@@ -161,7 +161,7 @@ def test_connect_root_proj_to_sla(session):
     project = MagicMock(spec=Project)
     project.is_root = True
     project.provider = MagicMock(spec=Provider)
-    project.provider.status = ProviderStatus.draft
+    project.provider.status = ProviderStatus.submitted
     sla = MagicMock(spec=Project)
     updated_by = MagicMock(spec=User)
 
@@ -195,12 +195,12 @@ def test_disconnect_proj_from_sla(session):
     project = MagicMock(spec=Project)
     project.is_root = False
     project.provider = MagicMock(spec=Provider)
-    project.provider.status = ProviderStatus.draft
+    project.provider.status = ProviderStatus.submitted
     updated_by = MagicMock(spec=User)
     disconnect_proj_from_sla(session=session, updated_by=updated_by, project=project)
     session.add.assert_called_once_with(project)
     session.commit.assert_called_once()
-    assert project.provider.status == ProviderStatus.draft
+    assert project.provider.status == ProviderStatus.submitted
     assert project.sla is None
     assert project.updated_by == updated_by
 
@@ -216,7 +216,7 @@ def test_disconnect_root_proj_from_sla(session):
     disconnect_proj_from_sla(session=session, updated_by=updated_by, project=project)
     session.add.assert_called_once_with(project)
     session.commit.assert_called_once()
-    assert project.provider.status == ProviderStatus.draft
+    assert project.provider.status == ProviderStatus.submitted
     assert project.sla is None
     assert project.updated_by == updated_by
 
@@ -229,7 +229,7 @@ def test_fail_disconnect_root_proj_from_sla(session):
     project = MagicMock(spec=Project)
     project.is_root = True
     project.provider = MagicMock(spec=Provider)
-    project.provider.status = ProviderStatus.submitted
+    project.provider.status = ProviderStatus.draft
     project.sla = MagicMock(spec=SLA)
     updated_by = MagicMock(spec=User)
     with pytest.raises(

--- a/tests/v1/schemas/test_provider_schemas.py
+++ b/tests/v1/schemas/test_provider_schemas.py
@@ -54,8 +54,8 @@ def test_provider_status_enum_all_values():
     """Test all ProviderStatus enum values and their integer representations."""
     status_map = {
         "draft": 0,
-        "ready": 1,
-        "submitted": 2,
+        "submitted": 1,
+        "ready": 2,
         "evaluation": 3,
         "pre_production": 4,
         "active": 5,


### PR DESCRIPTION
Implements the behavior defined in #51.
Updated tests related to this change of behavior (crud and endpoints calls, and schemas definition)