### PR TITLE
fix filtering on provider status

### DIFF
--- a/fed_mgr/v1/crud.py
+++ b/fed_mgr/v1/crud.py
@@ -296,10 +296,9 @@ def _get_conditions(
     """
     conditions = []
     for k, v in kwargs.items():
-        cond = _handle_special_date_fields(entity, k, v)
-        if cond is not None:
-            conditions.append(cond)
-        cond = _handle_generic_field(entity, k, v)
+        cond = _handle_special_date_fields(entity, k, v) or _handle_generic_field(
+            entity, k, v
+        )
         if cond is not None:
             conditions.append(cond)
     return conditions


### PR DESCRIPTION
The _handle_generic_field function did not handle lists. 
If the user requests to filter an entity based on a specific attributes and they provides a list of allowed values, now the function filters the table's entries and keep only those whose attribute's value is in the received list.